### PR TITLE
Update node_0_12

### DIFF
--- a/cloud66/node_0_12
+++ b/cloud66/node_0_12
@@ -1,4 +1,4 @@
 # {{Description: This deploy hook will run the following code snippet to automate the installation of the Node.}} 
 sudo apt-get install software-properties-common python-software-properties -y
-curl -sL https://deb.nodesource.com/setup | sudo bash -
+curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
 sudo apt-get install -y nodejs


### PR DESCRIPTION
Current URL in node_0_12 references the setup script that calls 0.10 instead of 0.12. This change forces the URL to use version 0.12.