### PR TITLE
awscli - Add snipper to install Pip and AWS CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ production: # Environment or your choice
       target: docker 
       sudo: true 
       execute: true
+      run_on: all_servers #make sure weave scope is running on all servers and communicate to each other
 ```
 
 *Warning:* Weavescope will run on port 4040 which is not exposed to the outside world. If you want to access the UI change your firewall settings allowing traffic to port 4040. Make sure only you can access weavescope from your ip-address. With weavescope you can control all your running process and excute inside running containers. Take good care of those powers!

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you want to install [weavescope](https://www.weave.works/products/weave-scope
 production: # Environment or your choice
   last_thing: # Importent to run the weavescope hook as the last thing during server deployment
     - snippet: cloud66/weave_scope # our weavescope snippet
-      target: any 
+      target: docker 
       sudo: true 
       execute: true
 ```

--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ production: # Environment
       sudo: true # Needed to install a package
       execute: true # Must be set to true for all snippets
 ```
+
+## weave_scope
+
+If you want to install [weavescope](https://www.weave.works/products/weave-scope/) on your Docker stack use the following *last_thing* hook.
+```
+production: # Environment or your choice
+  last_thing: # Importent to run the weavescope hook as the last thing during server deployment
+    - snippet: cloud66/weave_scope # our weavescope snippet
+      target: any 
+      sudo: true 
+      execute: true
+```
+
+*Warning:* Weavescope will run on port 4040 which is not exposed to the outside world. If you want to access the UI change your firewall settings allowing traffic to port 4040. Make sure only you can access weavescope from your ip-address. With weavescope you can control all your running process and excute inside running containers. Take good care of those powers!

--- a/cloud66/bower
+++ b/cloud66/bower
@@ -1,3 +1,4 @@
-# {{Description: This deploy hook will run the following code snippet to automates the installation of the Bower package manager.}} 
+# {{Description: This deploy hook will run the following code snippet to automates the installation of the Bower package manager.}}
+sudo apt-get install -y git-core nodejs npm nodejs-legacy
 sudo npm install -g bower
 yes | bower install --allow-root

--- a/cloud66/node_0_12
+++ b/cloud66/node_0_12
@@ -1,4 +1,4 @@
 # {{Description: This deploy hook will run the following code snippet to automate the installation of the Node.}} 
 sudo apt-get install software-properties-common python-software-properties -y
-curl -sL https://deb.nodesource.com/setup | sudo bash -
+curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
 sudo apt-get install -y nodejs

--- a/cloud66/node_5
+++ b/cloud66/node_5
@@ -1,0 +1,4 @@
+# {{Description: This deploy hook will run the following code snippet to automate the installation of Node.js v5.}}
+sudo apt-get install software-properties-common python-software-properties -y
+curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
+sudo apt-get install -y nodejs

--- a/cloud66/weave_scope
+++ b/cloud66/weave_scope
@@ -1,0 +1,4 @@
+# {{Description: This deploy hook will run the following code snippet to automates the installation of Weave Scope (a monitoring, visualisation & management tool for Docker).}}
+sudo wget -O /usr/local/bin/scope https://git.io/scope
+sudo chmod a+x /usr/local/bin/scope
+sudo scope launch


### PR DESCRIPTION
Using `pip` to install `awscli` ensures that the latest version of the tool is installed. As of this writing, the apt repositories seem to be using an older version that is missing functionality.
