### PR TITLE
Support current versions of Node.js

### DIFF
--- a/cloud66/node_6
+++ b/cloud66/node_6
@@ -1,0 +1,20 @@
+# {{Description: This snippet will automate the installation of Node.js v6.x}}
+
+# Verify Node.js 6.x - exit if already installed
+if (which nodejs > /dev/null && (nodejs -v | grep -q 'v6.')) then
+  exit
+fi
+
+# Remove old package version
+if (dpkg -l nodejs > /dev/null) then
+  sudo apt-get remove -y nodejs
+fi
+
+# Remove old apt source
+sudo rm -f /etc/apt/sources.list.d/nodesource.list
+
+# Add new apt source
+curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+
+# Install Node.js 6.x
+sudo apt-get install -y nodejs

--- a/cloud66/node_7
+++ b/cloud66/node_7
@@ -1,0 +1,20 @@
+# {{Description: This snippet will automate the installation of Node.js v7.x}}
+
+# Verify Node.js 7.x - exit if already installed
+if (which nodejs > /dev/null && (nodejs -v | grep -q 'v7.')) then
+  exit
+fi
+
+# Remove old package version
+if (dpkg -l nodejs > /dev/null) then
+  sudo apt-get remove -y nodejs
+fi
+
+# Remove old apt source
+sudo rm -f /etc/apt/sources.list.d/nodesource.list
+
+# Add new apt source
+curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+
+# Install Node.js 7.x
+sudo apt-get install -y nodejs


### PR DESCRIPTION
This PR adds snippets for installing Node.js versions `6.x` and `7.x`, including support for updating from previous versions if present.