### PR TITLE
Adds nginx newrelic agent snippet

### DIFF
--- a/cloud66/nginx_newrelic_agent
+++ b/cloud66/nginx_newrelic_agent
@@ -1,0 +1,27 @@
+# {{Description: This deploy hook will run the following code snippet to automate the installation of NewRelic Nginx plugin, and requires NEWRELIC_KEY and NEWRELIC_NGINX_NAME environment variables to be set on a stack.}}
+if [ -z "$NEWRELIC_KEY" ]
+then
+    >&2 echo "Please set your NEWRELIC_KEY environment variable"
+    exit 1
+elif [ -z "$NEWRELIC_NGINX_NAME" ]
+then
+    >&2 echo "Please set your NEWRELIC_NGINX_NAME environment variable"
+    exit 1
+else
+    if [ -s /etc/apt/sources.list.d/nginx.list ]
+		then
+        	sudo rm -f /etc/apt/sources.list.d/nginx.list
+          echo "deb http://nginx.org/packages/ubuntu/ trusty nginx" | sudo tee -a /etc/apt/sources.list.d/nginx.list
+		else
+          echo "deb http://nginx.org/packages/ubuntu/ trusty nginx" | sudo tee -a /etc/apt/sources.list.d/nginx.list
+		fi
+
+		sudo wget -O- http://nginx.org/keys/nginx_signing.key | sudo apt-key add -
+		sudo apt-get update -y
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install nginx-nr-agent crudini
+
+    sudo crudini --set --existing /etc/nginx-nr-agent/nginx-nr-agent.ini global newrelic_license_key $NEWRELIC_KEY
+    sudo crudini --set /etc/nginx-nr-agent/nginx-nr-agent.ini source1 name $NEWRELIC_NGINX_NAME
+    sudo crudini --set /etc/nginx-nr-agent/nginx-nr-agent.ini source1 url http://127.0.0.1:8559/status
+    sudo /etc/init.d/nginx-nr-agent start
+fi


### PR DESCRIPTION
Snippet that will add the nginx plugin into newrelic: https://www.nginx.com/blog/nginx-plugin-for-new-relic/

output:

```
deb http://nginx.org/packages/ubuntu/ trusty nginx
--2017-01-18 16:08:37--  http://nginx.org/keys/nginx_signing.key
Resolving nginx.org (nginx.org)... 95.211.80.227, 206.251.255.63, 2001:1af8:4060:a004:21::e3, ...
Connecting to nginx.org (nginx.org)|95.211.80.227|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1561 (1.5K) [application/octet-stream]
Saving to: 'STDOUT'

100%[================================================================================================================================================================================================================================================================================================================================================================================================================================================================>] 1,561       --.-K/s   in 0s

2017-01-18 16:08:37 (207 MB/s) - written to stdout [1561/1561]

OK
Get:1 http://security.ubuntu.com trusty-security InRelease [65.9 kB]
Ign http://azure.archive.ubuntu.com trusty InRelease
Get:2 http://azure.archive.ubuntu.com trusty-updates InRelease [65.9 kB]
Hit http://azure.archive.ubuntu.com trusty-backports InRelease
Get:3 http://nginx.org trusty InRelease [3569 B]
Hit http://azure.archive.ubuntu.com trusty Release.gpg
Hit http://azure.archive.ubuntu.com trusty Release
Get:4 http://azure.archive.ubuntu.com trusty-updates/main Sources [388 kB]
Get:5 http://azure.archive.ubuntu.com trusty-updates/restricted Sources [5911 B]
Get:6 http://azure.archive.ubuntu.com trusty-updates/universe Sources [171 kB]
Get:7 http://security.ubuntu.com trusty-security/main Sources [123 kB]
Get:8 http://azure.archive.ubuntu.com trusty-updates/multiverse Sources [7535 B]
Get:9 http://azure.archive.ubuntu.com trusty-updates/main amd64 Packages [938 kB]
Get:10 http://security.ubuntu.com trusty-security/universe Sources [47.3 kB]
Get:11 http://nginx.org trusty/nginx amd64 Packages [5528 B]
Get:12 http://azure.archive.ubuntu.com trusty-updates/restricted amd64 Packages [16.4 kB]
Get:13 http://security.ubuntu.com trusty-security/main amd64 Packages [573 kB]
Get:14 http://azure.archive.ubuntu.com trusty-updates/universe amd64 Packages [392 kB]
Get:15 http://azure.archive.ubuntu.com trusty-updates/multiverse amd64 Packages [14.0 kB]
Get:16 http://azure.archive.ubuntu.com trusty-updates/main Translation-en [460 kB]
Get:17 http://security.ubuntu.com trusty-security/universe amd64 Packages [148 kB]
Get:18 http://security.ubuntu.com trusty-security/main Translation-en [317 kB]
Get:19 http://azure.archive.ubuntu.com trusty-updates/multiverse Translation-en [7340 B]
Get:20 http://security.ubuntu.com trusty-security/universe Translation-en [87.2 kB]
Get:21 http://azure.archive.ubuntu.com trusty-updates/restricted Translation-en [3847 B]
Get:22 http://azure.archive.ubuntu.com trusty-updates/universe Translation-en [208 kB]
Hit http://azure.archive.ubuntu.com trusty-backports/main Sources
Hit http://azure.archive.ubuntu.com trusty-backports/restricted Sources
Hit http://azure.archive.ubuntu.com trusty-backports/universe Sources
Hit http://azure.archive.ubuntu.com trusty-backports/multiverse Sources
Hit http://azure.archive.ubuntu.com trusty-backports/main amd64 Packages
Hit http://azure.archive.ubuntu.com trusty-backports/restricted amd64 Packages
Hit http://azure.archive.ubuntu.com trusty-backports/universe amd64 Packages
Hit http://azure.archive.ubuntu.com trusty-backports/multiverse amd64 Packages
Hit http://azure.archive.ubuntu.com trusty-backports/main Translation-en
Hit http://azure.archive.ubuntu.com trusty-backports/multiverse Translation-en
Hit http://azure.archive.ubuntu.com trusty-backports/restricted Translation-en
Hit http://azure.archive.ubuntu.com trusty-backports/universe Translation-en
Hit http://azure.archive.ubuntu.com trusty/main Sources
Hit http://azure.archive.ubuntu.com trusty/restricted Sources
Hit http://azure.archive.ubuntu.com trusty/universe Sources
Hit http://azure.archive.ubuntu.com trusty/multiverse Sources
Hit http://azure.archive.ubuntu.com trusty/main amd64 Packages
Hit http://azure.archive.ubuntu.com trusty/restricted amd64 Packages
Hit http://azure.archive.ubuntu.com trusty/universe amd64 Packages
Hit http://azure.archive.ubuntu.com trusty/multiverse amd64 Packages
Hit http://azure.archive.ubuntu.com trusty/main Translation-en
Hit http://azure.archive.ubuntu.com trusty/multiverse Translation-en
Hit http://azure.archive.ubuntu.com trusty/restricted Translation-en
Ign http://nginx.org trusty/nginx Translation-en
Hit http://azure.archive.ubuntu.com trusty/universe Translation-en
Get:23 https://oss-binaries.phusionpassenger.com trusty InRelease
Ign https://oss-binaries.phusionpassenger.com trusty InRelease
Hit https://oss-binaries.phusionpassenger.com trusty Release.gpg
Hit https://oss-binaries.phusionpassenger.com trusty Release
Hit https://oss-binaries.phusionpassenger.com trusty/main amd64 Packages
Get:24 https://oss-binaries.phusionpassenger.com trusty/main Translation-en
Hit https://apt.dockerproject.org ubuntu-trusty InRelease
Ign https://oss-binaries.phusionpassenger.com trusty/main Translation-en
Hit https://apt.dockerproject.org ubuntu-trusty/main amd64 Packages
Get:25 https://apt.dockerproject.org ubuntu-trusty/main Translation-en
Ign https://apt.dockerproject.org ubuntu-trusty/main Translation-en
Fetched 4048 kB in 1s (2063 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following extra packages will be installed:
  python-daemon python-iniparse python-lockfile python-setproctitle
The following NEW packages will be installed:
  crudini nginx-nr-agent python-daemon python-iniparse python-lockfile
  python-setproctitle
0 upgraded, 6 newly installed, 0 to remove and 3 not upgraded.
Need to get 74.9 kB of archives.
After this operation, 503 kB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu/ trusty/universe python-iniparse all 0.4-2.1build1 [21.5 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu/ trusty/universe crudini amd64 0.3-1 [6298 B]
Get:3 http://nginx.org/packages/ubuntu/ trusty/nginx nginx-nr-agent all 2.0.0-10 [12.8 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu/ trusty/main python-lockfile all 1:0.8-2ubuntu2 [8090 B]
Get:5 http://azure.archive.ubuntu.com/ubuntu/ trusty/universe python-daemon all 1.5.5-1ubuntu1 [17.5 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu/ trusty-updates/universe python-setproctitle amd64 1.0.1-1ubuntu1.14.04.2 [8700 B]
Fetched 74.9 kB in 0s (635 kB/s)
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_CTYPE = "fr_FR.UTF-8",
	LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
Selecting previously unselected package python-iniparse.
(Reading database ... 40603 files and directories currently installed.)
Preparing to unpack .../python-iniparse_0.4-2.1build1_all.deb ...
Unpacking python-iniparse (0.4-2.1build1) ...
Selecting previously unselected package crudini.
Preparing to unpack .../crudini_0.3-1_amd64.deb ...
Unpacking crudini (0.3-1) ...
Selecting previously unselected package python-lockfile.
Preparing to unpack .../python-lockfile_1%3a0.8-2ubuntu2_all.deb ...
Unpacking python-lockfile (1:0.8-2ubuntu2) ...
Selecting previously unselected package python-daemon.
Preparing to unpack .../python-daemon_1.5.5-1ubuntu1_all.deb ...
Unpacking python-daemon (1.5.5-1ubuntu1) ...
Selecting previously unselected package python-setproctitle.
Preparing to unpack .../python-setproctitle_1.0.1-1ubuntu1.14.04.2_amd64.deb ...
Unpacking python-setproctitle (1.0.1-1ubuntu1.14.04.2) ...
Selecting previously unselected package nginx-nr-agent.
Preparing to unpack .../nginx-nr-agent_2.0.0-10_all.deb ...
----------------------------------------------------------------------

Thanks for using NGINX!

NGINX agent for New Relic is installed. Configuration file is:
/etc/nginx-nr-agent/nginx-nr-agent.ini

Documentation and configuration examples are available here:
/usr/share/doc/nginx-nr-agent/README.txt

Please use "service nginx-nr-agent" to control the agent daemon.

More information about NGINX products is available on:
* https://www.nginx.com/

----------------------------------------------------------------------
Unpacking nginx-nr-agent (2.0.0-10) ...
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
Processing triggers for ureadahead (0.100.0-16) ...
Setting up python-iniparse (0.4-2.1build1) ...
Setting up crudini (0.3-1) ...
Setting up python-lockfile (1:0.8-2ubuntu2) ...
Setting up python-daemon (1.5.5-1ubuntu1) ...
Setting up python-setproctitle (1.0.1-1ubuntu1.14.04.2) ...
Setting up nginx-nr-agent (2.0.0-10) ...
Processing triggers for ureadahead (0.100.0-16) ...
```