### PR TITLE
Prefers to setup weave scope on weave cloud

### DIFF
--- a/cloud66/weave_scope
+++ b/cloud66/weave_scope
@@ -1,4 +1,10 @@
-# {{Description: This deploy hook will run the following code snippet to automates the installation of Weave Scope (a monitoring, visualisation & management tool for Docker).}}
-sudo wget -O /usr/local/bin/scope https://git.io/scope
-sudo chmod a+x /usr/local/bin/scope
-sudo scope launch
+# {{Description: This deploy hook will run the following code snippet to automates the installation of Weave Scope (a monitoring, visualisation & management tool for Docker) and requires the WEAVE_SCOPE_TOKEN environment variable to be set on a stack.}}
+if [ -z "$WEAVE_SCOPE_TOKEN" ]
+then
+        >&2 echo "Please set your WEAVE_SCOPE_TOKEN environment variable"
+        exit 1
+else
+        sudo wget -O /usr/local/bin/scope https://git.io/scope
+        sudo chmod a+x /usr/local/bin/scope
+        scope launch --service-token=$WEAVE_SCOPE_TOKEN
+fi


### PR DESCRIPTION
Weave Cloud is the recommended option if:

* You are deploying to larger clusters.
* You require secure remote access.
* You want to share access with your coworkers.

It will require to setup `WEAVE_SCOPE_TOKEN` env on each stack.