### PR TITLE
Updated the snippet, now installing New Relic Infrastructure.

### DIFF
--- a/cloud66/newrelic
+++ b/cloud66/newrelic
@@ -4,18 +4,12 @@ then
         >&2 echo "Please set your NEWRELIC_KEY environment variable"
         exit 1
 else
-        if [ -s /etc/apt/sources.list.d/newrelic.list ]
-		then
-        	sudo rm -f /etc/apt/sources.list.d/newrelic.list
-        	echo "deb http://apt.newrelic.com/debian/ newrelic non-free" | sudo tee -a /etc/apt/sources.list.d/newrelic.list
-		else
-        	echo "deb http://apt.newrelic.com/debian/ newrelic non-free" | sudo tee -a /etc/apt/sources.list.d/newrelic.list
-		fi
-		
-		sudo wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
-		sudo apt-get update -y
-		sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install newrelic-sysmond
+	echo "license_key: ${NEWRELIC_KEY}" | sudo tee -a /etc/newrelic-infra.yml
+	curl https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
+	cat /etc/lsb-release
 
-        sudo nrsysmond-config --set license_key=$NEWRELIC_KEY
-        sudo /etc/init.d/newrelic-sysmond start
+	printf 'deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt xenial main' | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+
+	sudo apt update
+	sudo apt install newrelic-infra -y
 fi

--- a/cloud66/newrelic
+++ b/cloud66/newrelic
@@ -4,12 +4,18 @@ then
         >&2 echo "Please set your NEWRELIC_KEY environment variable"
         exit 1
 else
-	echo "license_key: ${NEWRELIC_KEY}" | sudo tee -a /etc/newrelic-infra.yml
-	curl https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
-	cat /etc/lsb-release
+        if [ -s /etc/apt/sources.list.d/newrelic.list ]
+		then
+        	sudo rm -f /etc/apt/sources.list.d/newrelic.list
+        	echo "deb http://apt.newrelic.com/debian/ newrelic non-free" | sudo tee -a /etc/apt/sources.list.d/newrelic.list
+		else
+        	echo "deb http://apt.newrelic.com/debian/ newrelic non-free" | sudo tee -a /etc/apt/sources.list.d/newrelic.list
+		fi
+		
+		sudo wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
+		sudo apt-get update -y
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install newrelic-sysmond
 
-	printf 'deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt xenial main' | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
-
-	sudo apt update
-	sudo apt install newrelic-infra -y
+        sudo nrsysmond-config --set license_key=$NEWRELIC_KEY
+        sudo /etc/init.d/newrelic-sysmond start
 fi

--- a/cloud66/newrelic-infra
+++ b/cloud66/newrelic-infra
@@ -1,21 +1,14 @@
-# {{Description: This deploy hook will run the following code snippet to automate the installation of NewRelic, and requires the NEWRELIC_KEY environment variable to be set on a stack.}}
+# {{Description: This deploy hook will run the following code snippet to automate the installation of NewRelic, and requires the NEWRELIC_KEY environment variable to be set on a stack.}} 
 if [ -z "$NEWRELIC_KEY" ]
 then
         >&2 echo "Please set your NEWRELIC_KEY environment variable"
         exit 1
 else
-        if [ -s /etc/apt/sources.list.d/newrelic-infra.list ]
-		then
-        	sudo rm -f /etc/apt/sources.list.d/newrelic-infra.list
-          printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt trusty main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
-		else
-          printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt trusty main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
-		fi
+	echo "license_key: ${NEWRELIC_KEY}" | sudo tee /etc/newrelic-infra.yml
+	curl https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
 
-    printf "license_key: %s\n" "$NEWRELIC_KEY" | sudo tee -a /etc/newrelic-infra.yml
+	printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/newrelic-infra.list
 
-		sudo wget -O- https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
-		sudo apt-get update -y
-		sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install newrelic-infra
-    sudo initctl start newrelic-infra
+	sudo apt update
+	sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install newrelic-infra
 fi

--- a/cloud66/newrelic-infrastructure
+++ b/cloud66/newrelic-infrastructure
@@ -1,0 +1,14 @@
+# {{Description: This deploy hook will run the following code snippet to automate the installation of NewRelic, and requires the NEWRELIC_KEY environment variable to be set on a stack.}} 
+if [ -z "$NEWRELIC_KEY" ]
+then
+        >&2 echo "Please set your NEWRELIC_KEY environment variable"
+        exit 1
+else
+	echo "license_key: ${NEWRELIC_KEY}" > /etc/newrelic-infra.yml
+	curl https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
+
+	printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+
+	sudo apt update
+	sudo apt install newrelic-infra -y
+fi


### PR DESCRIPTION
New Relic Infrastructure supersedes New Relic Servers. The latter is
no longer supported.