### PR TITLE
Modified codename for 22.04 dist to match standards as jammy. This wi…

### DIFF
--- a/cloud66/newrelic-infra
+++ b/cloud66/newrelic-infra
@@ -12,7 +12,7 @@ case $UBUNTU_VERSION in
   22.04 )
     printf "license_key: %s\n" "$NEWRELIC_KEY" | sudo tee /etc/newrelic-infra.yml
     curl https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
-    printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt focal main" | sudo tee /etc/apt/sources.list.d/newrelic-infra.list
+    printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt jammy main" | sudo tee /etc/apt/sources.list.d/newrelic-infra.list
     sudo apt-get update
     sudo apt-get install newrelic-infra -y
     Message="New relic is installed successfully for Ubuntu 22.04"


### PR DESCRIPTION
Updated newrelic-infra snippet to now properly point to New Relic's Infra Agent for Ubuntu 22.04 (jammy).